### PR TITLE
Update opngreduc.h

### DIFF
--- a/src/opngreduc/opngreduc.h
+++ b/src/opngreduc/opngreduc.h
@@ -10,6 +10,7 @@
 #define OPNGREDUC_H
 
 #include "png.h"
+#include "string.h"
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
To avoid warnings about use of memcpy and memset w/o be declared